### PR TITLE
prevent error if no textarea is present

### DIFF
--- a/frontendforms.js
+++ b/frontendforms.js
@@ -425,7 +425,9 @@ function jumpToAnchor() {
  */
 function maxCharsCounterReverse() {
     const textarea = document.querySelector("textarea");
-
+    if (!textarea) {
+        return;
+    }
     textarea.addEventListener("input", event => {
         const target = event.currentTarget;
         const maxLength = target.getAttribute("maxlength");


### PR DESCRIPTION
on a page without forms I get the error "Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')"

This fix prevents this.