### PR TITLE
Fix wrong path generation in Tag.php when adding namespace paths for classLoader

### DIFF
--- a/Formelements/Tag.php
+++ b/Formelements/Tag.php
@@ -20,7 +20,7 @@ use ProcessWire\WireException;
 use ProcessWire\WirePermissionException;
 
 
-\ProcessWire\wire('classLoader')->addNamespace('ProcessWire', '.'.__DIR__ . 'FrontendForms');
+\ProcessWire\wire('classLoader')->addNamespace('ProcessWire', __DIR__);
 
 abstract class Tag extends Wire
 {


### PR DESCRIPTION
Hi @juergenweb,
past time I was getting quite a lot of warnings in TracyDebugger log panel and finally was able to track it down:
The dot in front of path was throwing errors:
```
is_file(): open_basedir restriction in effect. File(./home/.../mydomain.app/public_html/site/modules/FrontendForms/FormelementsFrontendForms/Home.php) is not within the allowed path(s): (/home/.../mydomain.app:/tmp:/usr/share/pear) in /home/.../mydomain.app/public_html/wire/core/WireClassLoader.php:354
```

The `WireClassLoader.php:354` code is checking with `is_file()` and the dot in front makes the path not valid.

Also appending `__DIR__.'FrontendForms'` at the end is also wrong, as the current `__DIR__` path already includes this directory. Actually it's `/FrontendForms/Formelements/` as that's where the `Tag.php` is located.

It appears that making these changes might have fixed it. Although this error was happening quite randomly and I had not much success reproducing it myself, but I was seeing such log entries few times per day.

Not sure the `__DIR__` (like `/home/.../mydomain.app/public_html/site/modules/FrontendForms/Formelements/`) is the correct path in this file context, but I hope you will be able to take a look into this.

Thanks!